### PR TITLE
Changing to a ClusterIP type, and removing the nodePort

### DIFF
--- a/hab-mgmt-sup/hab-mgmt-sup.yaml
+++ b/hab-mgmt-sup/hab-mgmt-sup.yaml
@@ -8,7 +8,6 @@ spec:
   ports:
   - name: "http"
     port: 9631
-    nodePort: 30631
     protocol: TCP
   - name: "gossip-tcp"
     port: 9638
@@ -16,7 +15,6 @@ spec:
   - name: "gossip-udp"
     port: 9638
     protocol: UDP
-  type: NodePort
   selector:
     app: habitat-mgmt-supervisor
 ---


### PR DESCRIPTION
On a cluster running in AWS, the supervisor never executed the hooks.  For this type of application, utilizing a ClusterIP is sufficient for the pods to communicate with one another, and does not require opening any ports on the host.

